### PR TITLE
Add Composer autoloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+
+/vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Added
+- Added composer autoloader
+- Added vendor to .gitignore
+- Updated namespace and instantion of Options class to allow autoloading
+
 ## [1.0.4] - 2020-02-16
 ### Fixed
 - Fixed bug in calling dpd_disclaimer_on_queries_custom_data instead of dpd_exclude_from_queries_custom_data

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "chrispian/draft-post-disclaimer",
+    "description": "Plugin to display a disclaimer on posts in a draft category.",
+    "type": "wordpress-plugin",
+    "authors": [
+        {
+            "name": "Chrispian"
+        }
+    ],
+    "require": {}
+}

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,8 @@
             "name": "Chrispian"
         }
     ],
+    "autoload": {
+        "psr-4": { "CHB\\DraftPostDisclaimer\\": "src/" }
+    },
     "require": {}
 }

--- a/draft-post-disclaimer.php
+++ b/draft-post-disclaimer.php
@@ -25,8 +25,10 @@ Namespace CHB\DraftPostDisclaimer;
 /**
  * Load up our dependencies.
  */
-require 'src/Disclaimer.php';
 require 'src/admin/Options.php';
+if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {

--- a/draft-post-disclaimer.php
+++ b/draft-post-disclaimer.php
@@ -25,7 +25,6 @@ Namespace CHB\DraftPostDisclaimer;
 /**
  * Load up our dependencies.
  */
-require 'src/admin/Options.php';
 if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
@@ -47,7 +46,7 @@ define( 'DRAFT_POST_DISCLAIMER_VERSION', '1.0.3' );
  */
 function run_draft_post_disclaimer() {
 
-	$options = new Options;
+	$options = new Admin\Options;
 	$options->run();
 
 	$plugin = new Disclaimer();

--- a/src/admin/Options.php
+++ b/src/admin/Options.php
@@ -6,7 +6,7 @@
  * @since  2020-02-15
  */
 
-Namespace CHB\DraftPostDisclaimer;
+Namespace CHB\DraftPostDisclaimer\Admin;
 
 class Options {
 


### PR DESCRIPTION
Once this change has been made, you'll need to run `composer install` to build the autoloader in the vendor folder.

It might be easier to understand the changes I made to `Options` to get it to autoload if you look at it commit by commit.

See #4 